### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -116,7 +116,7 @@ cmake -DGDX_SOURCE=~/sourcecode/libgdx-cpp REST_OF_CONFIG_FLAGS
 ## Differences from libgdx
 
 * The texture class constructors that received an managed texture data had to be changed to static constructors.
-This is because C++ contruction blocks us to use shared_pointers, so we had to make it two-phase-like. So instead of calling the constructor,
+This is because C++ construction blocks us to use shared_pointers, so we had to make it two-phase-like. So instead of calling the constructor,
 you'll have to call, for example:
 
 ```c++


### PR DESCRIPTION
@aevum, I've corrected a typographical error in the documentation of the [libgdx-cpp](https://github.com/aevum/libgdx-cpp) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.